### PR TITLE
change leng='en' to lang='en'

### DIFF
--- a/views/_layout.jade
+++ b/views/_layout.jade
@@ -1,5 +1,5 @@
 doctype
-html(leng="en")
+html(lang="en")
     head
         title!= settings.title
     


### PR DESCRIPTION
self explanatory. Fixed spelling mistake.
